### PR TITLE
Allow lowercase letters in account numbers.

### DIFF
--- a/lib/aba/validations.rb
+++ b/lib/aba/validations.rb
@@ -47,7 +47,7 @@ class Aba
               self.error_collection << "#{attribute} must be an unsigned number" unless value.to_s =~ /\A\d+\Z/
             end
           when :account_number
-            if value.to_s =~ /\A[0\ ]+\Z/ || value.to_s !~ /[a-z\d\ ]{1,9}/
+            if value.to_s =~ /\A[0\ ]+\Z/ || value.to_s !~ /\A[a-zA-Z\d\ ]{1,9}\Z/
               self.error_collection << "#{attribute} must be a valid account number"
             end
           when :becs

--- a/lib/aba/validations.rb
+++ b/lib/aba/validations.rb
@@ -47,7 +47,7 @@ class Aba
               self.error_collection << "#{attribute} must be an unsigned number" unless value.to_s =~ /\A\d+\Z/
             end
           when :account_number
-            if value.to_s =~ /\A[0\ ]+\Z/ || value.to_s !~ /\A[a-z\d\ ]{1,9}\Z/
+            if value.to_s =~ /\A[0\ ]+\Z/ || value.to_s !~ /[a-z\d\ ]{1,9}/
               self.error_collection << "#{attribute} must be a valid account number"
             end
           when :becs

--- a/spec/lib/aba/validations_spec.rb
+++ b/spec/lib/aba/validations_spec.rb
@@ -138,8 +138,7 @@ describe Aba::Validations do
       expect(subject.errors).to eq ["attr1 must be a valid account number"]
 
       subject.attr1 = "00 0A0"
-      expect(subject.valid?).to eq false
-      expect(subject.errors).to eq ["attr1 must be a valid account number"]
+      expect(subject.valid?).to eq true
 
       subject.attr1 = "00 111"
       expect(subject.valid?).to eq true

--- a/spec/lib/aba/validations_spec.rb
+++ b/spec/lib/aba/validations_spec.rb
@@ -137,6 +137,10 @@ describe Aba::Validations do
       expect(subject.valid?).to eq false
       expect(subject.errors).to eq ["attr1 must be a valid account number"]
 
+      subject.attr1 = "00 0!A0"
+      expect(subject.valid?).to eq false
+      expect(subject.errors).to eq ["attr1 must be a valid account number"]
+
       subject.attr1 = "00 0A0"
       expect(subject.valid?).to eq true
 


### PR DESCRIPTION
I did this because Cuscal allows uppercase letters in account numbers and on the backend side we also allow funding sources with such account numbers.